### PR TITLE
[DOCS] Fix Jaro-Winkler function name typos in string functions docs

### DIFF
--- a/docs/topics/impala_string_functions.xml
+++ b/docs/topics/impala_string_functions.xml
@@ -140,13 +140,13 @@ under the License.
 
       <li>
         <xref href="#string_functions/jaro_winkler_distance"
-          >JARO_WINKER_DISTANCE,
+          >JARO_WINKLER_DISTANCE,
         JW_DST</xref>
       </li>
 
       <li>
         <xref href="#string_functions/jaro_winkler_similarity"
-          >JARO_WINKER_SIMILARITY,
+          >JARO_WINKLER_SIMILARITY,
         JW_SIM</xref>
       </li>
 


### PR DESCRIPTION
This PR corrects typos in the string functions documentation:
- JARO_WINKER_DISTANCE  → JARO_WINKLER_DISTANCE
- JARO_WINKER_SIMILARITY → JARO_WINKLER_SIMILARITY

The correct function names include the "L" (Winkler), as seen in Impala
release notes and usage examples.
